### PR TITLE
GDPR - Non-personalized AdMob Ads

### DIFF
--- a/AdMob/com/mopub/mobileads/GooglePlayServicesBanner.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesBanner.java
@@ -1,12 +1,15 @@
 package com.mopub.mobileads;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.util.Log;
 
+import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
+import com.mopub.common.MoPub;
 import com.mopub.common.util.Views;
 
 import java.util.Map;
@@ -24,6 +27,7 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
     public static final String AD_WIDTH_KEY = "adWidth";
     public static final String AD_HEIGHT_KEY = "adHeight";
     public static final String LOCATION_KEY = "location";
+    public static final String NON_PERSONALIZED_ADS_KEY = "npa";
 
     private CustomEventBannerListener mBannerListener;
     private AdView mGoogleAdView;
@@ -60,8 +64,14 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
 
         mGoogleAdView.setAdSize(adSize);
 
+        Bundle networkExtras = new Bundle();
+        if (!MoPub.canCollectPersonalInformation()) {
+            networkExtras.putString(NON_PERSONALIZED_ADS_KEY, "1");
+        }
+
         final AdRequest adRequest = new AdRequest.Builder()
                 .setRequestAgent("MoPub")
+                .addNetworkExtrasBundle(AdMobAdapter.class, networkExtras)
                 .build();
 
         try {

--- a/AdMob/com/mopub/mobileads/GooglePlayServicesInterstitial.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesInterstitial.java
@@ -1,11 +1,14 @@
 package com.mopub.mobileads;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.util.Log;
 
+import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.InterstitialAd;
+import com.mopub.common.MoPub;
 
 import java.util.Map;
 
@@ -15,6 +18,7 @@ public class GooglePlayServicesInterstitial extends CustomEventInterstitial {
      */
     public static final String AD_UNIT_ID_KEY = "adUnitID";
     public static final String LOCATION_KEY = "location";
+    public static final String NON_PERSONALIZED_ADS_KEY = "npa";
 
     private CustomEventInterstitialListener mInterstitialListener;
     private InterstitialAd mGoogleInterstitialAd;
@@ -39,8 +43,14 @@ public class GooglePlayServicesInterstitial extends CustomEventInterstitial {
         mGoogleInterstitialAd.setAdListener(new InterstitialAdListener());
         mGoogleInterstitialAd.setAdUnitId(adUnitId);
 
+        Bundle networkExtras = new Bundle();
+        if (!MoPub.canCollectPersonalInformation()) {
+            networkExtras.putString(NON_PERSONALIZED_ADS_KEY, "1");
+        }
+
         final AdRequest adRequest = new AdRequest.Builder()
                 .setRequestAgent("MoPub")
+                .addNetworkExtrasBundle(AdMobAdapter.class, networkExtras)
                 .build();
 
         try {

--- a/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
@@ -1,6 +1,7 @@
 package com.mopub.mobileads;
 
 import android.app.Activity;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
@@ -8,6 +9,7 @@ import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.reward.RewardItem;
@@ -15,6 +17,7 @@ import com.google.android.gms.ads.reward.RewardedVideoAd;
 import com.google.android.gms.ads.reward.RewardedVideoAdListener;
 import com.mopub.common.BaseLifecycleListener;
 import com.mopub.common.LifecycleListener;
+import com.mopub.common.MoPub;
 import com.mopub.common.MoPubReward;
 
 import java.util.Map;
@@ -38,6 +41,11 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
      * Key to obtain AdMob ad unit ID from the extras provided by MoPub.
      */
     private static final String KEY_EXTRA_AD_UNIT_ID = "adunit";
+
+    /**
+     * Key to force ads to be non-personalized and not send any personal information.
+     */
+    public static final String KEY_NON_PERSONALIZED_ADS = "npa";
 
     /**
      * Flag to determine whether or not the adapter has been initialized.
@@ -166,8 +174,15 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
                     MoPubRewardedVideoManager
                             .onRewardedVideoLoadSuccess(GooglePlayServicesRewardedVideo.class, mAdUnitId);
                 } else {
+                    Bundle networkExtras = new Bundle();
+                    if (!MoPub.canCollectPersonalInformation()) {
+                        networkExtras.putString(KEY_NON_PERSONALIZED_ADS, "1");
+                    }
                     mRewardedVideoAd
-                            .loadAd(mAdUnitId, new AdRequest.Builder().setRequestAgent("MoPub").build());
+                            .loadAd(mAdUnitId, new AdRequest.Builder()
+                                .setRequestAgent("MoPub")
+                                .addNetworkExtrasBundle(AdMobAdapter.class, networkExtras)
+                                .build());
                 }
             }
         });

--- a/AdMob/com/mopub/nativeads/GooglePlayServicesNative.java
+++ b/AdMob/com/mopub/nativeads/GooglePlayServicesNative.java
@@ -1,11 +1,13 @@
 package com.mopub.nativeads;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 
+import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdLoader;
 import com.google.android.gms.ads.AdRequest;
@@ -13,6 +15,7 @@ import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.formats.NativeAdOptions;
 import com.google.android.gms.ads.formats.NativeAppInstallAd;
 import com.google.android.gms.ads.formats.NativeContentAd;
+import com.mopub.common.MoPub;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +54,11 @@ public class GooglePlayServicesNative extends CustomEventNative {
      * Key to set and obtain the experimental swap margins flag.
      */
     public static final String KEY_EXPERIMENTAL_EXTRA_SWAP_MARGINS = "swap_margins";
+
+    /**
+     * Key to force ads to be non-personalized and not send any personal information.
+     */
+    public static final String KEY_NON_PERSONALIZED_ADS = "npa";
 
     /**
      * Flag to determine whether or not the adapter has been initialized.
@@ -425,7 +433,15 @@ public class GooglePlayServicesNative extends CustomEventNative {
                             }
                         }
                     }).withNativeAdOptions(adOptions).build();
-            adLoader.loadAd(new AdRequest.Builder().setRequestAgent("MoPub").build());
+
+            Bundle networkExtras = new Bundle();
+            if (!MoPub.canCollectPersonalInformation()) {
+                networkExtras.putString(KEY_NON_PERSONALIZED_ADS, "1");
+            }
+            adLoader.loadAd(new AdRequest.Builder()
+                    .setRequestAgent("MoPub")
+                    .addNetworkExtrasBundle(AdMobAdapter.class, networkExtras)
+                    .build());
         }
 
         /**


### PR DESCRIPTION
Pass "npa" (non-personalized ads) to AdMob requests when consent is not given

see https://developers.google.com/admob/android/eu-consent#forward_consent_to_the_google_mobile_ads_sdk