### PR TITLE
Pass the AdMob "npa" via MoPub's GlobalMediationSettings

### DIFF
--- a/AdMob/com/mopub/mobileads/GooglePlayServicesBanner.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesBanner.java
@@ -2,7 +2,6 @@ package com.mopub.mobileads;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.util.Log;
 
 import com.google.ads.mediation.admob.AdMobAdapter;
@@ -10,6 +9,7 @@ import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
+import com.mopub.common.MediationSettings;
 import com.mopub.common.util.Views;
 
 import java.util.Map;
@@ -30,6 +30,7 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
 
     private CustomEventBannerListener mBannerListener;
     private AdView mGoogleAdView;
+    private Bundle npaBundle;
 
     @Override
     protected void loadBanner(
@@ -41,6 +42,16 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
         final String adUnitId;
         final int adWidth;
         final int adHeight;
+
+        final GooglePlayServicesMediationSettings globalMediationSettings =
+                MoPubRewardedVideoManager.getGlobalMediationSettings(GooglePlayServicesMediationSettings.class);
+
+        if (globalMediationSettings != null) {
+            npaBundle = globalMediationSettings.getNpaBundle();
+            if (npaBundle == null) {
+                npaBundle = new Bundle();
+            }
+        }
 
         if (extrasAreValid(serverExtras)) {
             adUnitId = serverExtras.get(AD_UNIT_ID_KEY);
@@ -67,7 +78,7 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
                 .setRequestAgent("MoPub")
                 // Consent collected from the MoPub’s consent dialogue should not be used to set up
                 // Google's personalization preference. Publishers should work with Google to be GDPR-compliant.
-                .addNetworkExtrasBundle(AdMobAdapter.class, getGooglePersonalizationPreference(localExtras))
+                .addNetworkExtrasBundle(AdMobAdapter.class, npaBundle)
                 .build();
 
         try {
@@ -85,17 +96,6 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
             mGoogleAdView.setAdListener(null);
             mGoogleAdView.destroy();
         }
-    }
-
-    private Bundle getGooglePersonalizationPreference(Map<String, Object> localExtras) {
-        Bundle extras = new Bundle();
-        if (localExtras.get("npa") != null) {
-            String personalizationPref = localExtras.get("npa").toString();
-            if (!TextUtils.isEmpty(personalizationPref)) {
-                extras.putString("npa", personalizationPref);
-            }
-        }
-        return extras;
     }
 
     private boolean extrasAreValid(Map<String, String> serverExtras) {
@@ -188,6 +188,21 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
                     errorCode = MoPubErrorCode.UNSPECIFIED;
             }
             return errorCode;
+        }
+    }
+
+    public static final class GooglePlayServicesMediationSettings implements MediationSettings {
+        private Bundle npaBundle;
+
+        public GooglePlayServicesMediationSettings() {
+        }
+
+        public GooglePlayServicesMediationSettings(Bundle bundle) {
+            this.npaBundle = bundle;
+        }
+
+        private Bundle getNpaBundle() {
+            return npaBundle;
         }
     }
 


### PR DESCRIPTION
* This PR **borrows the rewarded video API's `getGlobalMediationSettings()`** API as a shared source of mediation settings for all AdMob adapters No more `localExtras` usage
* Pass in a Bundle directly as advised by AdMob (https://developers.google.com/admob/android/eu-consent#forward_consent_to_the_google_mobile_ads_sdk)
* Usage (additional details to be published via documentation):

```java
Bundle extras = new Bundle();
extras.putString("npa", "1");

SdkConfiguration sdkConfiguration = new SdkConfiguration.Builder(adUnitId)
	.withMediationSettings(new GooglePlayServicesBanner.GooglePlayServicesMediationSettings(extras),
                            new GooglePlayServicesInterstitial.GooglePlayServicesMediationSettings(extras),
                            new GooglePlayServicesRewardedVideo.GooglePlayServicesMediationSettings(extras),
                            new GooglePlayServicesNative.GooglePlayServicesMediationSettings(extras))
	.build();

if (!MoPub.isSdkInitialized()) {
	MoPub.initializeSdk(this, sdkConfiguration, initSdkListener());
}
```