### PR TITLE
Fix AdMob's isLoaded() not called on main thread for mediation on Unity

### DIFF
--- a/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
@@ -58,6 +58,11 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
     private RewardedVideoAd mRewardedVideoAd;
 
     /**
+     * Flag to indicate whether the rewarded video has cached.
+     */
+    private boolean isAdLoaded;
+
+    /**
      * A {@link LifecycleListener} used to forward the activity lifecycle events from MoPub SDK to
      * Google Mobile Ads SDK.
      */
@@ -144,6 +149,7 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
                                           @NonNull Map<String, Object> localExtras,
                                           @NonNull Map<String, String> serverExtras)
             throws Exception {
+        isAdLoaded = false;
 
         if (TextUtils.isEmpty(serverExtras.get(KEY_EXTRA_AD_UNIT_ID))) {
             // Using class name as the network ID for this callback since the ad unit ID is
@@ -196,7 +202,7 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
 
     @Override
     protected boolean hasVideoAvailable() {
-        return mRewardedVideoAd != null && mRewardedVideoAd.isLoaded();
+        return mRewardedVideoAd != null && isAdLoaded;
     }
 
     @Override
@@ -216,6 +222,7 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
         MoPubRewardedVideoManager.onRewardedVideoLoadSuccess(
                 GooglePlayServicesRewardedVideo.class,
                 mAdUnitId);
+        isAdLoaded = true;
     }
 
     @Override

--- a/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
@@ -58,7 +58,9 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
     private RewardedVideoAd mRewardedVideoAd;
 
     /**
-     * Flag to indicate whether the rewarded video has cached.
+     * Flag to indicate whether the rewarded video has cached. AdMob's isLoaded() call crashes the
+     * app when called from a thread other than the main UI thread. Since this is unavoidable with
+     * some platforms, e.g. Unity, we implement this workaround.
      */
     private boolean isAdLoaded;
 
@@ -191,12 +193,11 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
     }
 
     private void forwardNpaIfSet(AdRequest.Builder builder) {
-        final GooglePlayServicesMediationSettings globalMediationSettings =
-                MoPubRewardedVideoManager.getGlobalMediationSettings(GooglePlayServicesMediationSettings.class);
 
         // Only forward the "npa" bundle if it is explicitly set. Otherwise, don't attach it with the ad request.
-        if (globalMediationSettings != null && globalMediationSettings.getNpaBundle() != null) {
-            builder.addNetworkExtrasBundle(AdMobAdapter.class, globalMediationSettings.getNpaBundle());
+        if (GooglePlayServicesMediationSettings.getNpaBundle() != null &&
+                !GooglePlayServicesMediationSettings.getNpaBundle().isEmpty()) {
+            builder.addNetworkExtrasBundle(AdMobAdapter.class, GooglePlayServicesMediationSettings.getNpaBundle());
         }
     }
 
@@ -301,20 +302,20 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
     }
 
     public static final class GooglePlayServicesMediationSettings implements MediationSettings {
-        private Bundle npaBundle;
+        private static Bundle npaBundle;
 
         public GooglePlayServicesMediationSettings() {
         }
 
         public GooglePlayServicesMediationSettings(Bundle bundle) {
-            this.npaBundle = bundle;
+            npaBundle = bundle;
         }
 
         public void setNpaBundle(Bundle bundle) {
-            this.npaBundle = bundle;
+            npaBundle = bundle;
         }
 
-        private Bundle getNpaBundle() {
+        private static Bundle getNpaBundle() {
             return npaBundle;
         }
     }


### PR DESCRIPTION
* This is a fix for ADF-3407.
* Replace a call to Google's `RewardedVideoAd.isLoaded()` with a local boolean set to true when MoPub's `onRewardedVideoLoadSuccess()` fires. `hasVideoAvailable` then returns that boolean.