### PR TITLE
Add manual impression tracking to select ad formats

### DIFF
--- a/AdColony/com/mopub/mobileads/AdColonyInterstitial.java
+++ b/AdColony/com/mopub/mobileads/AdColonyInterstitial.java
@@ -65,6 +65,8 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
             return;
         }
 
+        setAutomaticImpressionAndClickTracking(false);
+
         String clientOptions = DEFAULT_CLIENT_OPTIONS;
         String appId = DEFAULT_APP_ID;
         String[] allZoneIds = DEFAULT_ALL_ZONE_IDS;
@@ -179,6 +181,7 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
                         @Override
                         public void run() {
                             mCustomEventInterstitialListener.onInterstitialShown();
+                            mCustomEventInterstitialListener.onInterstitialImpression();
                         }
                     });
                 }

--- a/AdMob/com/mopub/mobileads/GooglePlayServicesBanner.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesBanner.java
@@ -36,6 +36,9 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
             final CustomEventBannerListener customEventBannerListener,
             final Map<String, Object> localExtras,
             final Map<String, String> serverExtras) {
+
+        setAutomaticImpressionAndClickTracking(false);
+
         mBannerListener = customEventBannerListener;
         final String adUnitId;
         final int adWidth;
@@ -127,6 +130,12 @@ public class GooglePlayServicesBanner extends CustomEventBanner {
         /*
          * Google Play Services AdListener implementation
          */
+
+        @Override
+        public void onAdImpression() {
+            mBannerListener.onBannerImpression();
+        }
+
         @Override
         public void onAdClosed() {
 

--- a/AdMob/com/mopub/mobileads/GooglePlayServicesInterstitial.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesInterstitial.java
@@ -28,6 +28,9 @@ public class GooglePlayServicesInterstitial extends CustomEventInterstitial {
             final CustomEventInterstitialListener customEventInterstitialListener,
             final Map<String, Object> localExtras,
             final Map<String, String> serverExtras) {
+
+        setAutomaticImpressionAndClickTracking(false);
+
         mInterstitialListener = customEventInterstitialListener;
         final String adUnitId;
 
@@ -129,6 +132,7 @@ public class GooglePlayServicesInterstitial extends CustomEventInterstitial {
             Log.d("MoPub", "Showing Google Play Services interstitial ad.");
             if (mInterstitialListener != null) {
                 mInterstitialListener.onInterstitialShown();
+                mInterstitialListener.onInterstitialImpression();
             }
         }
 

--- a/AppLovin/com/mopub/mobileads/AppLovinBanner.java
+++ b/AppLovin/com/mopub/mobileads/AppLovinBanner.java
@@ -45,6 +45,8 @@ public class AppLovinBanner extends CustomEventBanner {
     @Override
     protected void loadBanner(final Context context, final CustomEventBannerListener customEventBannerListener, final Map<String, Object> localExtras, final Map<String, String> serverExtras) {
 
+        setAutomaticImpressionAndClickTracking(false);
+
         // Pass the user consent from the MoPub SDK to AppLovin as per GDPR
         boolean canCollectPersonalInfo = MoPub.canCollectPersonalInformation();
         AppLovinPrivacySettings.setHasUserConsent(canCollectPersonalInfo, context);
@@ -69,6 +71,7 @@ public class AppLovinBanner extends CustomEventBanner {
                 @Override
                 public void adDisplayed(final AppLovinAd ad) {
                     MoPubLog.d("Banner displayed");
+                    customEventBannerListener.onBannerImpression();
                 }
 
                 @Override

--- a/AppLovin/com/mopub/mobileads/AppLovinInterstitial.java
+++ b/AppLovin/com/mopub/mobileads/AppLovinInterstitial.java
@@ -51,6 +51,8 @@ public class AppLovinInterstitial extends CustomEventInterstitial implements App
     @Override
     public void loadInterstitial(final Context context, final CustomEventInterstitialListener listener, final Map<String, Object> localExtras, final Map<String, String> serverExtras) {
 
+        setAutomaticImpressionAndClickTracking(false);
+
         // Pass the user consent from the MoPub SDK to AppLovin as per GDPR
         boolean canCollectPersonalInfo = MoPub.canCollectPersonalInformation();
         AppLovinPrivacySettings.setHasUserConsent(canCollectPersonalInfo, context);
@@ -159,6 +161,7 @@ public class AppLovinInterstitial extends CustomEventInterstitial implements App
     public void adDisplayed(final AppLovinAd appLovinAd) {
         MoPubLog.d("Interstitial displayed");
         listener.onInterstitialShown();
+        listener.onInterstitialImpression();
     }
 
     @Override

--- a/Chartboost/com/mopub/mobileads/ChartboostInterstitial.java
+++ b/Chartboost/com/mopub/mobileads/ChartboostInterstitial.java
@@ -34,6 +34,8 @@ class ChartboostInterstitial extends CustomEventInterstitial {
         Preconditions.checkNotNull(localExtras);
         Preconditions.checkNotNull(serverExtras);
 
+        setAutomaticImpressionAndClickTracking(false);
+
         if (!(context instanceof Activity)) {
             interstitialListener.onInterstitialFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
             return;

--- a/Chartboost/com/mopub/mobileads/ChartboostShared.java
+++ b/Chartboost/com/mopub/mobileads/ChartboostShared.java
@@ -13,7 +13,6 @@ import com.mopub.common.MoPubReward;
 import com.mopub.common.Preconditions;
 import com.mopub.common.VisibleForTesting;
 import com.mopub.common.logging.MoPubLog;
-import com.mopub.common.privacy.PersonalInfoManager;
 import com.mopub.mobileads.CustomEventInterstitial.CustomEventInterstitialListener;
 
 import java.util.Collections;
@@ -117,6 +116,10 @@ public class ChartboostShared {
                     }
 
                     @Override
+                    public void onInterstitialImpression() {
+                    }
+
+                    @Override
                     public void onLeaveApplication() {
                     }
 
@@ -208,6 +211,7 @@ public class ChartboostShared {
         public void didDisplayInterstitial(String location) {
             MoPubLog.d("Chartboost interstitial ad shown.");
             getInterstitialListener(location).onInterstitialShown();
+            getInterstitialListener(location).onInterstitialImpression();
         }
 
         //******************

--- a/FacebookAudienceNetwork/com/mopub/mobileads/FacebookBanner.java
+++ b/FacebookAudienceNetwork/com/mopub/mobileads/FacebookBanner.java
@@ -32,6 +32,9 @@ public class FacebookBanner extends CustomEventBanner implements AdListener {
                               final CustomEventBannerListener customEventBannerListener,
                               final Map<String, Object> localExtras,
                               final Map<String, String> serverExtras) {
+
+        setAutomaticImpressionAndClickTracking(false);
+
         mBannerListener = customEventBannerListener;
 
         final String placementId;
@@ -111,6 +114,7 @@ public class FacebookBanner extends CustomEventBanner implements AdListener {
     @Override
     public void onLoggingImpression(Ad ad) {
         MoPubLog.d("Facebook banner ad logged impression.");
+        mBannerListener.onBannerImpression();
     }
 
     private boolean serverExtrasAreValid(final Map<String, String> serverExtras) {

--- a/FacebookAudienceNetwork/com/mopub/mobileads/FacebookInterstitial.java
+++ b/FacebookAudienceNetwork/com/mopub/mobileads/FacebookInterstitial.java
@@ -53,6 +53,9 @@ public class FacebookInterstitial extends CustomEventInterstitial implements Int
                                     final CustomEventInterstitialListener customEventInterstitialListener,
                                     final Map<String, Object> localExtras,
                                     final Map<String, String> serverExtras) {
+
+        setAutomaticImpressionAndClickTracking(false);
+
         MoPubLog.d("Loading Facebook interstitial");
         mInterstitialListener = customEventInterstitialListener;
 
@@ -153,6 +156,7 @@ public class FacebookInterstitial extends CustomEventInterstitial implements Int
     @Override
     public void onLoggingImpression(Ad ad) {
         MoPubLog.d("Facebook interstitial ad logged impression.");
+        mInterstitialListener.onInterstitialImpression();
     }
 
     @Override

--- a/Flurry/com/mopub/mobileads/FlurryCustomEventInterstitial.java
+++ b/Flurry/com/mopub/mobileads/FlurryCustomEventInterstitial.java
@@ -56,6 +56,8 @@ class FlurryCustomEventInterstitial extends com.mopub.mobileads.CustomEventInter
             return;
         }
 
+        setAutomaticImpressionAndClickTracking(false);
+
         mContext = context;
         mListener = listener;
 
@@ -131,6 +133,7 @@ class FlurryCustomEventInterstitial extends com.mopub.mobileads.CustomEventInter
 
             if (mListener != null) {
                 mListener.onInterstitialShown();
+                mListener.onInterstitialImpression();
             }
         }
 

--- a/IronSource/com/mopub/mobileads/IronSourceInterstitial.java
+++ b/IronSource/com/mopub/mobileads/IronSourceInterstitial.java
@@ -47,6 +47,8 @@ public class IronSourceInterstitial extends CustomEventInterstitial implements I
     @Override
     protected void loadInterstitial(Context context, CustomEventInterstitialListener customEventInterstitialListener, Map<String, Object> map0, Map<String, String> serverExtras) {
 
+        setAutomaticImpressionAndClickTracking(false);
+
         MoPubLifecycleManager.getInstance((Activity) context).addLifecycleListener(lifecycleListener);
         // Pass the user consent from the MoPub SDK to ironSource as per GDPR
         boolean canCollectPersonalInfo = MoPub.canCollectPersonalInformation();
@@ -215,6 +217,7 @@ public class IronSourceInterstitial extends CustomEventInterstitial implements I
             public void run() {
                 if (mMoPubListener != null) {
                     mMoPubListener.onInterstitialShown();
+                    mMoPubListener.onInterstitialImpression();
                 }
             }
         });

--- a/OnebyAOL/com/mopub/mobileads/MillennialInterstitial.java
+++ b/OnebyAOL/com/mopub/mobileads/MillennialInterstitial.java
@@ -52,6 +52,9 @@ final class MillennialInterstitial extends CustomEventInterstitial {
     protected void loadInterstitial(final Context context,
                                     final CustomEventInterstitialListener customEventInterstitialListener, final Map<String, Object> localExtras,
                                     final Map<String, String> serverExtras) {
+
+        setAutomaticImpressionAndClickTracking(false);
+
         interstitialListener = customEventInterstitialListener;
         this.context = context;
 
@@ -269,6 +272,7 @@ final class MillennialInterstitial extends CustomEventInterstitial {
                 @Override
                 public void run() {
                     interstitialListener.onInterstitialShown();
+                    interstitialListener.onInterstitialImpression();
                 }
             });
         }

--- a/Tapjoy/com/mopub/mobileads/TapjoyInterstitial.java
+++ b/Tapjoy/com/mopub/mobileads/TapjoyInterstitial.java
@@ -55,6 +55,9 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
                                     CustomEventInterstitialListener customEventInterstitialListener,
                                     Map<String, Object> localExtras,
                                     Map<String, String> serverExtras) {
+
+        setAutomaticImpressionAndClickTracking(false);
+
         MoPubLog.d("Requesting Tapjoy interstitial");
 
         mInterstitialListener = customEventInterstitialListener;
@@ -193,6 +196,7 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
             @Override
             public void run() {
                 mInterstitialListener.onInterstitialShown();
+                mInterstitialListener.onInterstitialImpression();
             }
         });
     }

--- a/UnityAds/com/mopub/mobileads/UnityInterstitial.java
+++ b/UnityAds/com/mopub/mobileads/UnityInterstitial.java
@@ -22,6 +22,8 @@ public class UnityInterstitial extends CustomEventInterstitial implements IUnity
                                     Map<String, Object> localExtras,
                                     Map<String, String> serverExtras) {
 
+        setAutomaticImpressionAndClickTracking(false);
+
         mPlacementId = UnityRouter.placementIdForServerExtras(serverExtras, mPlacementId);
         mCustomEventInterstitialListener = customEventInterstitialListener;
         mContext = context;
@@ -74,6 +76,7 @@ public class UnityInterstitial extends CustomEventInterstitial implements IUnity
     @Override
     public void onUnityAdsStart(String placementId) {
         mCustomEventInterstitialListener.onInterstitialShown();
+        mCustomEventInterstitialListener.onInterstitialImpression();
     }
 
     @Override

--- a/Vungle/com/mopub/mobileads/VungleInterstitial.java
+++ b/Vungle/com/mopub/mobileads/VungleInterstitial.java
@@ -53,6 +53,9 @@ public class VungleInterstitial extends CustomEventInterstitial {
                                     CustomEventInterstitialListener customEventInterstitialListener,
                                     Map<String, Object> localExtras,
                                     Map<String, String> serverExtras) {
+
+        setAutomaticImpressionAndClickTracking(false);
+
         mCustomEventInterstitialListener = customEventInterstitialListener;
         mIsPlaying = false;
 
@@ -209,6 +212,7 @@ public class VungleInterstitial extends CustomEventInterstitial {
                     @Override
                     public void run() {
                         mCustomEventInterstitialListener.onInterstitialShown();
+                        mCustomEventInterstitialListener.onInterstitialImpression();
                     }
                 });
             }


### PR DESCRIPTION
*AdColony*
Interstitial

*AdMob*
Banner
Interstitial

*AppLovin*
Banner
Interstitial

*Chartboost*
Interstitial

*Facebook*
Banner
Interstitial

*Flurry*
Interstitial

*ironSource*
Interstitial

*One by AOL / Millennial*
-Banner- SDK does not have an equivalent callback for impression tracking / ad opened: https://github.com/mopub/mopub-android-mediation/blob/master/OnebyAOL/com/mopub/mobileads/MillennialBanner.java#L164-L270
Interstitial

*Tapjoy*
Interstitial

*Unity*
Interstitial

*Vungle*
Interstitial