### PR TITLE
Adding null check

### DIFF
--- a/OnebyAOL/com/mopub/nativeads/MillennialNative.java
+++ b/OnebyAOL/com/mopub/nativeads/MillennialNative.java
@@ -240,7 +240,10 @@ public class MillennialNative extends CustomEventNative {
 
             // Add MM native assets that don't have a direct MoPub mapping
             addExtra("disclaimer", nativeAd.getDisclaimer().getText());
-            addExtra("rating", nativeAd.getRating().getText());
+            if ( nativeAd.getRating() != null ) {
+                addExtra("rating", nativeAd.getRating().getText());
+            }
+
 
             MillennialUtils.postOnUiThread(new Runnable() {
                 @Override


### PR DESCRIPTION
One by AOL native ads often don't come with a rating field (it's called out in their docs -- http://docs.onemobilesdk.aol.com/android-ad-sdk/native-types.html ). Null checking is necessary for the line accessing it.