### PR TITLE
Vungle's AutoRotation set on by default

### DIFF
--- a/Vungle/com/mopub/mobileads/VungleInterstitial.java
+++ b/Vungle/com/mopub/mobileads/VungleInterstitial.java
@@ -97,6 +97,9 @@ public class VungleInterstitial extends CustomEventInterstitial {
             Object ordinalViewCount = localExtras.get(ORDINAL_VIEW_COUNT_KEY);
             if (ordinalViewCount instanceof Integer)
                 mAdConfig.setOrdinal((Integer) ordinalViewCount);
+			
+			//	Set autorotation
+			mAdConfig.setAutoRotate(true);
         }
 
         sVungleRouter.loadAdForPlacement(mPlacementId, mVungleRouterListener);

--- a/Vungle/com/mopub/mobileads/VungleRewardedVideo.java
+++ b/Vungle/com/mopub/mobileads/VungleRewardedVideo.java
@@ -128,6 +128,9 @@ public class VungleRewardedVideo extends CustomEventRewardedVideo {
     protected void showVideo() {
         final AdConfig adConfig = new AdConfig();
         setUpMediationSettingsForRequest(adConfig);
+		
+		//	Set autorotation
+		adConfig.setAutoRotate(true);
 
         sVungleRouter.playAdForPlacement(mPlacementId, adConfig);
         mIsPlaying = true;


### PR DESCRIPTION
The Vungle ad view activity would flip the device orientation because of the missing autoRotate setting. Fixed now. Not sure why it wasn't enabled by default in the first place.
