### PR TITLE
Check for null before mRewardedVideoAd.loadAd

### DIFF
--- a/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
@@ -178,7 +178,7 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
                 if (mRewardedVideoAd != null && mRewardedVideoAd.isLoaded()) {
                     MoPubRewardedVideoManager
                             .onRewardedVideoLoadSuccess(GooglePlayServicesRewardedVideo.class, mAdUnitId);
-                } else {
+                } else if (mRewardedVideoAd != null) {
                     AdRequest.Builder builder = new AdRequest.Builder();
                     builder.setRequestAgent("MoPub");
 


### PR DESCRIPTION
Fix a received NPE crash at com.mopub.mobileads.GooglePlayServicesRewardedVideo$2.run (GooglePlayServicesRewardedVideo:190), which is mRewardedVideoAd.loadAd(mAdUnitId, adRequest), by confirming mRewardedVideoAd is not null before calling.

Similar to the null check added a few days ago on first part of the if statement: https://github.com/mopub/mopub-android-mediation/pull/98