### PR TITLE
Fix NPE calling RewardedVideoAd loadAd() method

### DIFF
--- a/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
@@ -175,7 +175,10 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                if (mRewardedVideoAd != null && mRewardedVideoAd.isLoaded()) {
+                if (mRewardedVideoAd == null) {
+                    return;
+                }
+                if (mRewardedVideoAd.isLoaded()) {
                     MoPubRewardedVideoManager
                             .onRewardedVideoLoadSuccess(GooglePlayServicesRewardedVideo.class, mAdUnitId);
                 } else {


### PR DESCRIPTION
Looks like https://github.com/mopub/mopub-android-mediation/pull/98 is not enough. We still try to load ad on null object