### PR TITLE
Null check to avoid NPEs for mRewardedVideoAd.loadAd calls

### DIFF
--- a/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
+++ b/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java
@@ -178,7 +178,7 @@ public class GooglePlayServicesRewardedVideo extends CustomEventRewardedVideo im
                 if (mRewardedVideoAd != null && mRewardedVideoAd.isLoaded()) {
                     MoPubRewardedVideoManager
                             .onRewardedVideoLoadSuccess(GooglePlayServicesRewardedVideo.class, mAdUnitId);
-                } else {
+                } else if (mRewardedVideoAd != null) {
                     AdRequest.Builder builder = new AdRequest.Builder();
                     builder.setRequestAgent("MoPub");
 


### PR DESCRIPTION
When using separate threads, avoid NPEs on calls to mRewardedVideoAd.loadAd(mAdUnitId, adRequest) (https://github.com/mopub/mopub-android-mediation/blob/master/AdMob/com/mopub/mobileads/GooglePlayServicesRewardedVideo.java#L197)