### PR TITLE
check if the placement are null

### DIFF
--- a/Tapjoy/com/mopub/mobileads/TapjoyInterstitial.java
+++ b/Tapjoy/com/mopub/mobileads/TapjoyInterstitial.java
@@ -167,8 +167,12 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
 
     @Override
     protected void showInterstitial() {
-        MoPubLog.log(SHOW_ATTEMPTED, ADAPTER_NAME);
-        tjPlacement.showContent();
+        if (tjPlacement != null) {
+            MoPubLog.log(SHOW_ATTEMPTED, ADAPTER_NAME);
+            tjPlacement.showContent();
+        }else {
+            MoPubLog.log(SHOW_FAILED, ADAPTER_NAME, MoPubErrorCode.NETWORK_NO_FILL.getIntCode(), MoPubErrorCode.NETWORK_NO_FILL);
+        }
     }
 
     // Tapjoy

--- a/Tapjoy/com/mopub/mobileads/TapjoyRewardedVideo.java
+++ b/Tapjoy/com/mopub/mobileads/TapjoyRewardedVideo.java
@@ -185,6 +185,9 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
 
     @Override
     protected boolean hasVideoAvailable() {
+        if (tjPlacement == null) {
+            return false;
+        }
         return tjPlacement.isContentAvailable();
     }
 


### PR DESCRIPTION
This PR is suggesting to check if the placement instance is null before accessing it in Tapjoy Adapter classes , `TapjoyRewardedVideo.java` and `TapjoyInterstitial.java`. 