### PR TITLE
update fetch bidding token API for Tapjoy

### DIFF
--- a/Tapjoy/src/main/java/com/mopub/mobileads/TapjoyAdapterConfiguration.java
+++ b/Tapjoy/src/main/java/com/mopub/mobileads/TapjoyAdapterConfiguration.java
@@ -26,7 +26,6 @@ public class TapjoyAdapterConfiguration extends BaseAdapterConfiguration {
 
     // Adapter's keys
     private static final String ADAPTER_VERSION = BuildConfig.VERSION_NAME;
-    private static final String BIDDING_TOKEN = "1";
     private static final String MOPUB_NETWORK_NAME = BuildConfig.NETWORK_NAME;
 
     @NonNull
@@ -39,7 +38,7 @@ public class TapjoyAdapterConfiguration extends BaseAdapterConfiguration {
     @Override
     public String getBiddingToken(@NonNull Context context) {
         Preconditions.checkNotNull(context);
-        return BIDDING_TOKEN;
+        return Tapjoy.getUserToken();
     }
 
     @NonNull


### PR DESCRIPTION
- With current adapter source when Tapjoy token is not available  In those cases, we return "1" as the token. Hence update the API to not return "1"