### PR TITLE
Adcolony Adapter 4.1.4.0

### DIFF
--- a/AdColony/CHANGELOG.md
+++ b/AdColony/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+  * 4.1.4.0
+    * This version of the adapters has been certified with AdColony 4.1.4.
+    * Fix NPE crash issue while requesting ad from onExpiring callback.
+    
   * 4.1.3.0
     * This version of the adapters has been certified with AdColony 4.1.3.
     * Log the AdColony zone id in ad lifecycle events.

--- a/AdColony/build.gradle
+++ b/AdColony/build.gradle
@@ -1,4 +1,4 @@
-project.version = '4.1.3.0'
+project.version = '4.1.4.0'
 
 apply from: '../shared-build.gradle'
 

--- a/AdColony/src/main/java/com/mopub/mobileads/AdColonyInterstitial.java
+++ b/AdColony/src/main/java/com/mopub/mobileads/AdColonyInterstitial.java
@@ -186,7 +186,9 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
                 @Override
                 public void onExpiring(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
                     MoPubLog.log(getAdNetworkId(), CUSTOM, ADAPTER_NAME, "AdColony interstitial is expiring; requesting new ad.");
-                    AdColony.requestInterstitial(ad.getZoneID(), mAdColonyInterstitialListener);
+                    if (mAdColonyInterstitialListener != null) {
+                        AdColony.requestInterstitial(ad.getZoneID(), mAdColonyInterstitialListener);
+                    }
                 }
 
                 @Override

--- a/AdColony/src/main/java/com/mopub/mobileads/AdColonyRewardedVideo.java
+++ b/AdColony/src/main/java/com/mopub/mobileads/AdColonyRewardedVideo.java
@@ -382,7 +382,9 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
 
         @Override
         public void onExpiring(@NonNull AdColonyInterstitial ad) {
-            AdColony.requestInterstitial(ad.getZoneID(), ad.getListener(), mAdOptions);
+            if (ad.getListener() != null) {
+                AdColony.requestInterstitial(ad.getZoneID(), ad.getListener(), mAdOptions);
+            }
         }
 
         @Override


### PR DESCRIPTION
Update Adcolony SDK v4.1.4.0.
Fix NPE crash issue while requesting ad from onExpiring callback.