### PR TITLE
Google - Avoid redundant image asset download

### DIFF
--- a/AdMob/src/main/java/com/mopub/nativeads/GooglePlayServicesNative.java
+++ b/AdMob/src/main/java/com/mopub/nativeads/GooglePlayServicesNative.java
@@ -343,8 +343,6 @@ public class GooglePlayServicesNative extends CustomEventNative {
             // MoPub allows for only one image, so only request for one image.
             optionsBuilder.setRequestMultipleImages(false);
 
-            optionsBuilder.setReturnUrlsForImageAssets(false);
-
             // Get the preferred image orientation from the local extras.
             if (localExtras.containsKey(KEY_EXTRA_ORIENTATION_PREFERENCE)
                     && isValidOrientationExtra(localExtras.get(KEY_EXTRA_ORIENTATION_PREFERENCE))) {


### PR DESCRIPTION
The setting a few lines above is correct: https://github.com/mopub/mopub-android-mediation/blob/5d36ceb0e1ebd2b5c35c588f9742a7e7d68ba15d/AdMob/src/main/java/com/mopub/nativeads/GooglePlayServicesNative.java#L339-L341

The setting back to false causes redundant image load. It is a regression in #86 

The Google `NativeAd.Image.getDrawable()` is not used, since MoPub does its own image fetch. So this library should keep the setting enabled and remove the line disabling it. (This PR.)

Documentation:

> setReturnUrlsForImageAssets()
>
> Image assets for native ads are returned via instances of NativeAd.Image, which holds a Drawable and a Uri. If this option is set to false (which is the default), the Google Mobile Ads SDK fetches image assets automatically and populates both the Drawable and the Uri for you. If it's set to true, however, the SDK instead populates just the Uri field, allowing you to download the actual images at your discretion.

https://developers.google.com/admob/android/native/options