### PR TITLE
Update Tapjoy Adapter to 12.6.0

### DIFF
--- a/Tapjoy/build.gradle
+++ b/Tapjoy/build.gradle
@@ -1,4 +1,4 @@
-project.version = '12.4.2.0'
+project.version = '12.6.0.0'
 
 apply from: '../shared-build.gradle'
 

--- a/Tapjoy/src/main/java/com/mopub/mobileads/TapjoyInterstitial.java
+++ b/Tapjoy/src/main/java/com/mopub/mobileads/TapjoyInterstitial.java
@@ -24,6 +24,7 @@ import com.tapjoy.TJConnectListener;
 import com.tapjoy.TJError;
 import com.tapjoy.TJPlacement;
 import com.tapjoy.TJPlacementListener;
+import com.tapjoy.TJPrivacyPolicy;
 import com.tapjoy.Tapjoy;
 
 import org.json.JSONException;
@@ -52,6 +53,7 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
     public static final String ADAPTER_NAME = TapjoyInterstitial.class.getSimpleName();
     private static final String ADM_KEY = "adm";
     private String mPlacementName;
+    private static TJPrivacyPolicy tjPrivacyPolicy;
 
     @NonNull
     private TapjoyAdapterConfiguration mTapjoyAdapterConfiguration;
@@ -66,6 +68,7 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
 
     public TapjoyInterstitial() {
         mTapjoyAdapterConfiguration = new TapjoyAdapterConfiguration();
+        tjPrivacyPolicy = Tapjoy.getPrivacyPolicy();
     }
 
     @Override
@@ -151,14 +154,14 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
             Boolean gdprApplies = personalInfoManager.gdprApplies();
 
             if (gdprApplies != null) {
-                Tapjoy.subjectToGDPR(gdprApplies);
+                tjPrivacyPolicy.setSubjectToGDPR(gdprApplies);
 
                 if (gdprApplies) {
                     String userConsented = MoPub.canCollectPersonalInformation() ? "1" : "0";
 
-                    Tapjoy.setUserConsent(userConsented);
+                    tjPrivacyPolicy.setUserConsent(userConsented);
                 } else {
-                    Tapjoy.setUserConsent("-1");
+                    tjPrivacyPolicy.setUserConsent("-1");
                 }
             }
         }

--- a/Tapjoy/src/main/java/com/mopub/mobileads/TapjoyRewardedVideo.java
+++ b/Tapjoy/src/main/java/com/mopub/mobileads/TapjoyRewardedVideo.java
@@ -20,6 +20,7 @@ import com.tapjoy.TJPlacement;
 import com.tapjoy.TJPlacementListener;
 import com.tapjoy.TJPlacementVideoListener;
 import com.tapjoy.Tapjoy;
+import com.tapjoy.TJPrivacyPolicy;
 
 import org.json.JSONException;
 
@@ -56,6 +57,7 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
     private boolean isAutoConnect = false;
     private static String sPlacementName;
     private static TapjoyRewardedVideoListener sTapjoyListener = new TapjoyRewardedVideoListener();
+    private static TJPrivacyPolicy tjPrivacyPolicy;
     @NonNull
     private TapjoyAdapterConfiguration mTapjoyAdapterConfiguration;
 
@@ -81,6 +83,7 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
 
     public TapjoyRewardedVideo() {
         mTapjoyAdapterConfiguration = new TapjoyAdapterConfiguration();
+        tjPrivacyPolicy = Tapjoy.getPrivacyPolicy();
     }
 
     @Override
@@ -234,14 +237,14 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
             Boolean gdprApplies = personalInfoManager.gdprApplies();
 
             if (gdprApplies != null) {
-                Tapjoy.subjectToGDPR(gdprApplies);
+                tjPrivacyPolicy.setSubjectToGDPR(gdprApplies);
 
                 if (gdprApplies) {
                     String userConsented = MoPub.canCollectPersonalInformation() ? "1" : "0";
 
-                    Tapjoy.setUserConsent(userConsented);
+                    tjPrivacyPolicy.setUserConsent(userConsented);
                 } else {
-                    Tapjoy.setUserConsent("-1");
+                    tjPrivacyPolicy.setUserConsent("-1");
                 }
             }
         }


### PR DESCRIPTION
This PR is to update MoPub Tapjoy Adapter to 12.6.0.0 to support Tapjoy SDK version 12.6.0 and replace the deprecated GDPR and user consent APIs with Tapjoy new GDPR and user consent API.

Tested with mopub sample app and no issues found with new updates.

**Note**: We will inform when official Tapjoy SDK 12.6.0 is released. Please review this PR after Tapjoy SDK 12.6.0 is released. 