### PR TITLE
Remove the Context check from the Applovin adapter.

### DIFF
--- a/AppLovin/src/main/java/com/mopub/mobileads/AppLovinBanner.java
+++ b/AppLovin/src/main/java/com/mopub/mobileads/AppLovinBanner.java
@@ -77,21 +77,6 @@ public class AppLovinBanner extends BaseAd {
         boolean canCollectPersonalInfo = MoPub.canCollectPersonalInformation();
         AppLovinPrivacySettings.setHasUserConsent(canCollectPersonalInfo, context);
 
-        // SDK versions BELOW 7.1.0 require a instance of an Activity to be passed in as the context
-        if (AppLovinSdk.VERSION_CODE < 710 && !(context instanceof Activity)) {
-            MoPubLog.log(getAdNetworkId(), CUSTOM, ADAPTER_NAME, "Unable to request AppLovin banner. Invalid context provided");
-
-            MoPubLog.log(getAdNetworkId(), LOAD_FAILED, ADAPTER_NAME,
-                    MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR.getIntCode(),
-                    MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
-
-            if (mLoadListener != null) {
-                mLoadListener.onAdLoadFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
-            }
-
-            return;
-        }
-
         final AppLovinAdSize adSize = appLovinAdSizeFromAdData(adData);
         if (adSize != null) {
             final String adMarkup = extras.get(DataKeys.ADM_KEY);

--- a/AppLovin/src/main/java/com/mopub/mobileads/AppLovinInterstitial.java
+++ b/AppLovin/src/main/java/com/mopub/mobileads/AppLovinInterstitial.java
@@ -96,20 +96,6 @@ public class AppLovinInterstitial extends BaseAd implements AppLovinAdLoadListen
         boolean canCollectPersonalInfo = MoPub.canCollectPersonalInformation();
         AppLovinPrivacySettings.setHasUserConsent(canCollectPersonalInfo, context);
 
-        // SDK versions BELOW 7.2.0 require a instance of an Activity to be passed in as the context
-        if (AppLovinSdk.VERSION_CODE < 720 && !(context instanceof Activity)) {
-            MoPubLog.log(getAdNetworkId(), CUSTOM, ADAPTER_NAME, "Unable to request AppLovin interstitial. Invalid context " +
-                    "provided.");
-
-            MoPubLog.log(getAdNetworkId(), LOAD_FAILED, ADAPTER_NAME,
-                    MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR.getIntCode(),
-                    MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
-            if (mLoadListener != null) {
-                mLoadListener.onAdLoadFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
-            }
-            return;
-        }
-
         // Store parent objects
         this.context = context;
 


### PR DESCRIPTION
It is no longer needed because it no longer integrates with previous versions of the Applovin SDK.