### PR TITLE
Remove listener from helper instead of nulling helper to avoid NPE.

### DIFF
--- a/Ogury/CHANGELOG.md
+++ b/Ogury/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Changelog
+ * 5.0.9.1
+  * Fixed NullPointerException caused by callbacks triggered after adapter invalidation.
  * 5.0.9.0
   * Initial commit. Add support for banner, interstitial and rewarded videos.
   * This version of the adapters has been certified with Ogury 5.0.9 and MoPub 5.17.0.

--- a/Ogury/build.gradle
+++ b/Ogury/build.gradle
@@ -1,4 +1,4 @@
-project.version = '5.0.9.0'
+project.version = '5.0.9.1'
 project.ext.networkName = 'ogury'
 
 apply from: '../shared-build.gradle'

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryBanner.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryBanner.java
@@ -113,7 +113,8 @@ public class OguryBanner extends BaseAd implements OguryBannerAdListener, OguryA
             mBanner = null;
         }
 
-        mListenerHelper = null;
+        mListenerHelper.setLoadListener(null);
+        mListenerHelper.setInteractionListener(null);
     }
 
     public static OguryBannerAdSize getBannerAdSize(Integer iAdWidth, Integer iAdHeight) {

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryBanner.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryBanner.java
@@ -112,9 +112,6 @@ public class OguryBanner extends BaseAd implements OguryBannerAdListener, OguryA
             mBanner.destroy();
             mBanner = null;
         }
-
-        mListenerHelper.setLoadListener(null);
-        mListenerHelper.setInteractionListener(null);
     }
 
     public static OguryBannerAdSize getBannerAdSize(Integer iAdWidth, Integer iAdHeight) {

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryInterstitial.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryInterstitial.java
@@ -119,9 +119,6 @@ public class OguryInterstitial extends BaseAd implements OguryInterstitialAdList
     @Override
     protected void onInvalidate() {
         mInterstitial = null;
-
-        mListenerHelper.setLoadListener(null);
-        mListenerHelper.setInteractionListener(null);
     }
 
     @Override

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryInterstitial.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryInterstitial.java
@@ -118,8 +118,10 @@ public class OguryInterstitial extends BaseAd implements OguryInterstitialAdList
 
     @Override
     protected void onInvalidate() {
-        mListenerHelper = null;
         mInterstitial = null;
+
+        mListenerHelper.setLoadListener(null);
+        mListenerHelper.setInteractionListener(null);
     }
 
     @Override

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryRewardedVideo.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryRewardedVideo.java
@@ -122,9 +122,6 @@ public class OguryRewardedVideo extends BaseAd implements OguryOptinVideoAdListe
     @Override
     protected void onInvalidate() {
         mOptInVideo = null;
-
-        mListenerHelper.setInteractionListener(null);
-        mListenerHelper.setLoadListener(null);
     }
 
     @Override

--- a/Ogury/src/main/java/com/mopub/mobileads/OguryRewardedVideo.java
+++ b/Ogury/src/main/java/com/mopub/mobileads/OguryRewardedVideo.java
@@ -121,8 +121,10 @@ public class OguryRewardedVideo extends BaseAd implements OguryOptinVideoAdListe
 
     @Override
     protected void onInvalidate() {
-        mListenerHelper = null;
         mOptInVideo = null;
+
+        mListenerHelper.setInteractionListener(null);
+        mListenerHelper.setLoadListener(null);
     }
 
     @Override


### PR DESCRIPTION
# Description

Due to publishers complaining about NPE, we changed the way to cleanup the listener in order to avoid setting the helper to null.

Example:
```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void com.mopub.mobileads.OguryAdListenerHelper.onAdLoaded()' on a null object reference
at com.mopub.mobileads.OguryInterstitial.onAdLoaded(OguryInterstitial.java:127)
at com.ogury.ed.internal.g.d(g.java:31)
at com.ogury.ed.internal.m$h.a(m.java:269)
at com.ogury.ed.internal.is.g(is.java:71)
at com.ogury.ed.internal.is.f(is.java:15)
at com.ogury.ed.internal.is$a.a(is.java:42)
at com.ogury.ed.internal.il.g(il.java:88)
at com.ogury.ed.internal.il.f(il.java:22)
at com.ogury.ed.internal.il$a.b(il.java:46)
at com.ogury.ed.internal.jk.onPageFinished(jk.java:21)
at Eu4.b(Eu4.java:2)
at dw.handleMessage(dw.java:62)
at android.os.Handler.dispatchMessage(Handler.java:105)
at android.os.Looper.loop(Looper.java:164)
at android.app.ActivityThread.main(ActivityThread.java:6944)
at java.lang.reflect.Method.invoke(Method.java)
at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:327)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1374)"
```