### PR TITLE
Snap Audience Network 2.3.0

### DIFF
--- a/SnapAudienceNetwork/build.gradle
+++ b/SnapAudienceNetwork/build.gradle
@@ -1,4 +1,4 @@
-project.version = '2.2.0.1'
+project.version = '2.3.0.0'
 project.ext.networkName = 'snap'
 
 apply from: '../shared-build.gradle'

--- a/SnapAudienceNetwork/src/main/java/com/mopub/mobileads/SnapAdInterstitial.java
+++ b/SnapAudienceNetwork/src/main/java/com/mopub/mobileads/SnapAdInterstitial.java
@@ -45,7 +45,7 @@ public class SnapAdInterstitial extends BaseAd {
     private static final String SLOT_ID_KEY = "slotId";
     private static final String APP_ID_KEY = "appId";
 
-    private static String mSlotId;
+    private String mSlotId;
 
     private final SnapAdAdapterConfiguration mSnapAdAdapterConfiguration;
 
@@ -158,7 +158,7 @@ public class SnapAdInterstitial extends BaseAd {
         try {
             MoPubLog.log(getAdNetworkId(), SHOW_ATTEMPTED, ADAPTER_NAME);
 
-            adsNetworkApi.playAd(new SnapAdKitSlot(null, AdKitSlotType.INTERSTITIAL));
+            adsNetworkApi.playAd(new SnapAdKitSlot(mSlotId, AdKitSlotType.INTERSTITIAL));
         } catch (Exception exception) {
             MoPubLog.log(getAdNetworkId(), CUSTOM, ADAPTER_NAME, "Failed to show Snap " +
                     "Audience Network Ads");

--- a/SnapAudienceNetwork/src/main/java/com/mopub/mobileads/SnapAdRewardedVideo.java
+++ b/SnapAudienceNetwork/src/main/java/com/mopub/mobileads/SnapAdRewardedVideo.java
@@ -50,7 +50,7 @@ public class SnapAdRewardedVideo extends BaseAd {
     private static final String SLOT_ID_KEY = "slotId";
     private static final String APP_ID_KEY = "appId";
 
-    private static String mSlotId;
+    private String mSlotId;
     private final SnapAdAdapterConfiguration mSnapAdAdapterConfiguration;
 
     public SnapAdRewardedVideo() {
@@ -170,7 +170,7 @@ public class SnapAdRewardedVideo extends BaseAd {
         MoPubLog.log(getAdNetworkId(), SHOW_ATTEMPTED, ADAPTER_NAME);
 
         try {
-            adsNetworkApi.playAd(new SnapAdKitSlot(null, AdKitSlotType.REWARDED));
+            adsNetworkApi.playAd(new SnapAdKitSlot(mSlotId, AdKitSlotType.REWARDED));
         } catch (Exception exception) {
             MoPubLog.log(getAdNetworkId(), CUSTOM_WITH_THROWABLE, ADAPTER_NAME, exception);
             MoPubLog.log(getAdNetworkId(), SHOW_FAILED, ADAPTER_NAME,


### PR DESCRIPTION
We released a new version of Snap Audience Network 2.3.0.  
Available here : https://mvnrepository.com/artifact/com.snap.adkit/adkit/2.3.0 

No changes to  Api.  